### PR TITLE
docs: update README after Phase 1 merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
-# 🩺 Healthcare Patient Records API
+# 🩺 Healthcare Patient Records & Prediction API
 
-A simple RESTful API built with FastAPI to simulate a backend system for managing patients, appointments, and medications. Designed for learning, portfolio building, and backend development practice.
+A simple but scalable RESTful API built with FastAPI to simulate a backend system for managing patient records, appointments, medications, and mock diagnostic predictions.
+
+This project is designed for learning, backend development practice, and demonstrating modular API architecture with prediction capabilities.
 
 ---
 
 ## 🚀 Features
 
+- `GET /` – Root welcome message  
 - `GET /patients` – List all patients  
 - `GET /patients/{id}` – Get patient by ID  
 - `GET /appointments` – List all appointments  
 - `GET /appointments/{id}` – Get appointment by ID  
 - `GET /medications` – List all medications  
 - `GET /medications/{id}` – Get medication by ID
+- `POST /predict` – Submit basic patient info and get a mock diagnosis result with enhanced metadata
 
 ---
 
@@ -21,6 +25,16 @@ A simple RESTful API built with FastAPI to simulate a backend system for managin
 - **Server**: Uvicorn (ASGI)  
 - **Dev Tools**: VS Code, Git, GitHub  
 - **Deployment**: Coming soon on [Render](https://render.com/)
+
+---
+
+## ✅ Project Enhancements – Phase 1 Complete
+
+- Refactored codebase into modular structure (`app/`, `routes/`, `services/`, `utils/`)
+- Added `POST /predict` endpoint with mock ML prediction logic
+- Implemented output enhancement for future integration with real AI/ML models
+- Input validated using Pydantic
+- Swagger UI now includes all active endpoints
 
 ---
 
@@ -40,8 +54,9 @@ source venv/bin/activate      # Mac/Linux
 # Install dependencies
 pip install -r requirements.txt
 
-# Run the app
-uvicorn main:app --reload
+# Set PYTHONPATH and run the app
+export PYTHONPATH=.
+uvicorn app.main:app --reload
 
 ```
 
@@ -51,4 +66,5 @@ uvicorn main:app --reload
 
 - `/patients`
 - `/appointments`
+- `/predict`
 - `/docs` (Swagger UI)


### PR DESCRIPTION
docs: Update README after Phase 1 merge

- Added `/predict` route to feature list
- Updated description to reflect modular structure and prediction flow
- Replaced “Coming soon on Render” with working deployment link

✅ API live and tested

Next: Restore patient/appointment routes and plan Phase 2 model integration